### PR TITLE
Named Plans with Tracers

### DIFF
--- a/tests/unit/SchedulerTests.swift
+++ b/tests/unit/SchedulerTests.swift
@@ -93,6 +93,38 @@ class SchedulerTests: XCTestCase {
       }
     }
   }
+  
+  private class ChangeBooleanNamedPlan: NSObject, NamedPlan {
+    var desiredBoolean: Bool
+    
+    init(desiredBoolean: Bool) {
+      self.desiredBoolean = desiredBoolean
+    }
+    
+    func performerClass() -> AnyClass {
+      return Performer.self
+    }
+    
+    public func copy(with zone: NSZone? = nil) -> Any {
+      return ChangeBooleanNamedPlan(desiredBoolean: desiredBoolean)
+    }
+    
+    private class Performer: NSObject, Performing, NamedPlanPerforming {
+      let target: State
+      required init(target: Any) {
+        self.target = target as! State
+      }
+      
+      func addPlan(_ plan: NamedPlan, named name: String) {
+        let testPlan = plan as! ChangeBooleanNamedPlan
+        target.boolean = testPlan.desiredBoolean
+      }
+      
+      func removePlan(named name: String) {
+        
+      }
+    }
+  }
 
   // Verify that two plans of the same type creates only one performer.
   func testTwoSamePlansCreatesOnePerformer() {
@@ -297,18 +329,21 @@ class SchedulerTests: XCTestCase {
   }
   
   func testNamedPlansRespectTracers() {
-    let differentPlan = IncrementerTargetPlan()
+    let differentPlan = ChangeBooleanNamedPlan(desiredBoolean:true)
     let state = State()
     let scheduler = Scheduler()
     let tracer = StorageTracer()
     scheduler.addTracer(tracer)
     
-    scheduler.addPlan(firstViewTargetAlteringPlan, named: "name_one", to: state)
+    scheduler.addPlan(firstViewTargetAlteringPlan, named: "name_one", to: target)
     scheduler.addPlan(differentPlan, named: "name_two", to: state)
     
     XCTAssertEqual(tracer.addedPlans.count, 2)
     XCTAssert(tracer.addedPlans[0] is NamedPlan)
-    XCTAssert(tracer.addedPlans[1] is IncrementerTargetPlan)
+    XCTAssert(tracer.addedPlans[1] is ChangeBooleanNamedPlan)
+    
+    XCTAssert(target.text == "removePlanInvokedaddPlanInvoked")
+    XCTAssert(state.boolean)
   }
 
   // A plan that enables hijacking of the delegated performance token blocks.

--- a/tests/unit/SchedulerTests.swift
+++ b/tests/unit/SchedulerTests.swift
@@ -295,6 +295,21 @@ class SchedulerTests: XCTestCase {
 
     waitForExpectations(timeout: 0.1)
   }
+  
+  func testNamedPlansRespectTracers() {
+    let differentPlan = IncrementerTargetPlan()
+    let state = State()
+    let scheduler = Scheduler()
+    let tracer = StorageTracer()
+    scheduler.addTracer(tracer)
+    
+    scheduler.addPlan(firstViewTargetAlteringPlan, named: "name_one", to: state)
+    scheduler.addPlan(differentPlan, named: "name_two", to: state)
+    
+    XCTAssertEqual(tracer.addedPlans.count, 2)
+    XCTAssert(tracer.addedPlans[0] is NamedPlan)
+    XCTAssert(tracer.addedPlans[1] is IncrementerTargetPlan)
+  }
 
   // A plan that enables hijacking of the delegated performance token blocks.
   private class HijackedIsActiveTokenGenerator: NSObject, Plan {


### PR DESCRIPTION
See https://github.com/material-motion/material-motion-runtime-objc/issues/80 for the original issue.

Unsure if we want to test out the NSNotifications part of this too as this looks to be getting deprecated. Easy test to add, but not sure if it's necessary to do so if it's getting deprecated.

Would also be good to test out that remove named plan callbacks are invoked, but will need to wait for https://github.com/material-motion/material-motion-runtime-objc/issues/94 to land first.

cc @jverkoey @rcameron @pingpongboss 
